### PR TITLE
refactor: annotate default colors as resource ids

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/data/TimelineConstants.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/data/TimelineConstants.kt
@@ -1,15 +1,16 @@
 package com.dmitrypokrasov.timelineview.data
 
+import androidx.annotation.ColorRes
 import com.google.android.material.R.color
 
 internal object TimelineConstants {
     const val DEFAULT_STEP_Y_SIZE = 150f
     const val DEFAULT_RADIUS_SIZE = 0f
     const val DEFAULT_STEP_Y_FIRST_SIZE = 0f
-    var DEFAULT_PROGRESS_COLOR = color.design_default_color_secondary
-    var DEFAULT_STROKE_COLOR = color.design_default_color_secondary_variant
-    var DEFAULT_TITLE_COLOR = color.design_default_color_on_secondary
-    var DEFAULT_DESCRIPTION_COLOR = color.design_default_color_on_secondary
+    @ColorRes val DEFAULT_PROGRESS_COLOR = color.design_default_color_secondary
+    @ColorRes val DEFAULT_STROKE_COLOR = color.design_default_color_secondary_variant
+    @ColorRes val DEFAULT_TITLE_COLOR = color.design_default_color_on_secondary
+    @ColorRes val DEFAULT_DESCRIPTION_COLOR = color.design_default_color_on_secondary
     const val DEFAULT_MARGIN_TOP_DESCRIPTION = 125f
     const val DEFAULT_MARGIN_TOP_TITLE = 125f
     const val DEFAULT_MARGIN_TOP_PROGRESS_ICON = 0f


### PR DESCRIPTION
## Summary
- mark default Timeline colors with `@ColorRes` and store them as resource IDs instead of mutable vars

## Testing
- `./gradlew :timelineview:assembleDebug` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689d08b8cb888322ac0c6d340d932e77