### PR TITLE
Separate paints for lines and text rendering

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUi.kt
@@ -40,8 +40,11 @@ internal class TimelineUi(
     /** Битмап текущей иконки прогресса. */
     private var iconProgressBitmap: Bitmap? = null
 
-    /** Основная кисть для рисования линий и текста. */
-    private val pLine = Paint()
+    /** Кисть для рисования линий. */
+    private val linePaint = Paint()
+
+    /** Кисть для рисования текста и иконок. */
+    private val textPaint = Paint()
 
     /**
      * Инициализирует визуальные элементы (битмапы, pathEffect).
@@ -68,20 +71,16 @@ internal class TimelineUi(
         }
     }
 
-    fun getTextAlign(): Paint.Align? {
-        return pLine.textAlign
-    }
-
     fun resetFromPaintTools() {
-        pLine.reset()
-        pLine.style = Paint.Style.STROKE
-        pLine.strokeWidth = uiConfig.sizeStroke
-        pLine.pathEffect = pathEffect
+        linePaint.reset()
+        linePaint.style = Paint.Style.STROKE
+        linePaint.strokeWidth = uiConfig.sizeStroke
+        linePaint.pathEffect = pathEffect
     }
 
     fun resetFromTextTools() {
-        pLine.reset()
-        pLine.isAntiAlias = true
+        textPaint.reset()
+        textPaint.isAntiAlias = true
     }
 
     fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
@@ -90,19 +89,19 @@ internal class TimelineUi(
                 it,
                 leftCoordinates,
                 topCoordinates,
-                pLine
+                textPaint
             )
         }
     }
 
     fun drawProgressPath(canvas: Canvas) {
-        pLine.color = uiConfig.colorProgress
-        canvas.drawPath(pathEnable, pLine)
+        linePaint.color = uiConfig.colorProgress
+        canvas.drawPath(pathEnable, linePaint)
     }
 
     fun drawDisablePath(canvas: Canvas) {
-        pLine.color = uiConfig.colorStroke
-        canvas.drawPath(pathDisable, pLine)
+        linePaint.color = uiConfig.colorStroke
+        canvas.drawPath(pathDisable, linePaint)
     }
 
     /**
@@ -112,15 +111,17 @@ internal class TimelineUi(
         canvas: Canvas,
         title: String,
         x: Float,
-        y: Float
+        y: Float,
+        align: Paint.Align
     ) {
-        pLine.apply {
-            this.textSize = uiConfig.sizeTitle
+        textPaint.apply {
+            textAlign = align
+            textSize = uiConfig.sizeTitle
             typeface = Typeface.DEFAULT_BOLD
             color = uiConfig.colorTitle
         }
 
-        canvas.drawText(title, x, y, pLine)
+        canvas.drawText(title, x, y, textPaint)
     }
 
     /**
@@ -130,15 +131,17 @@ internal class TimelineUi(
         canvas: Canvas,
         description: String,
         x: Float,
-        y: Float
+        y: Float,
+        align: Paint.Align
     ) {
-        pLine.apply {
-            this.textSize = uiConfig.sizeDescription
+        textPaint.apply {
+            textAlign = align
+            textSize = uiConfig.sizeDescription
             typeface = Typeface.DEFAULT
             color = uiConfig.colorDescription
         }
 
-        canvas.drawText(description, x, y, pLine)
+        canvas.drawText(description, x, y, textPaint)
     }
 
     /**
@@ -157,8 +160,8 @@ internal class TimelineUi(
             else -> iconDisableStep
         }
         bm?.let {
-            pLine.textAlign = align
-            canvas.drawBitmap(it, x, y, pLine)
+            textPaint.textAlign = align
+            canvas.drawBitmap(it, x, y, textPaint)
         }
     }
 

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineView.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineView.kt
@@ -50,6 +50,9 @@ class TimelineView @JvmOverloads constructor(
     /** Визуальная конфигурация таймлайна. */
     private var timelineUi: TimelineUi
 
+    /** Текущая сторона отрисовки (LEFT/RIGHT). */
+    private var currentSide: Paint.Align = Paint.Align.RIGHT
+
     init {
         timelineMath = TimelineMath(initMathConfig(attrs))
         timelineUi = TimelineUi(initUiConfig(attrs))
@@ -94,28 +97,32 @@ class TimelineView @JvmOverloads constructor(
         // Отрисовка шагов: иконки, заголовки, описания
         timelineUi.resetFromTextTools()
 
+        currentSide = Paint.Align.RIGHT
         var printProgressIcon = false
 
         timelineMath.mathConfig.steps.forEachIndexed { i, lvl ->
+            val align = currentSide
             if (i == 0) {
                 timelineUi.printTitle(
                     canvas,
                     resources.getString(lvl.title),
-                    timelineMath.getTitleXCoordinates(Paint.Align.RIGHT),
-                    timelineMath.getTitleYCoordinates(i)
+                    timelineMath.getTitleXCoordinates(align),
+                    timelineMath.getTitleYCoordinates(i),
+                    align
                 )
                 timelineUi.printDescription(
                     canvas,
                     resources.getString(lvl.description),
-                    timelineMath.getTitleXCoordinates(Paint.Align.RIGHT),
-                    timelineMath.getDescriptionYCoordinates(i)
+                    timelineMath.getTitleXCoordinates(align),
+                    timelineMath.getDescriptionYCoordinates(i),
+                    align
                 )
                 timelineUi.printIcon(
                     lvl,
                     canvas,
-                    Paint.Align.RIGHT,
+                    align,
                     context,
-                    timelineMath.getIconXCoordinates(Paint.Align.RIGHT),
+                    timelineMath.getIconXCoordinates(align),
                     timelineMath.getIconYCoordinates(i)
                 )
 
@@ -128,7 +135,6 @@ class TimelineView @JvmOverloads constructor(
                     printProgressIcon = true
                 }
             } else {
-
                 if (lvl.percents != 100 && !printProgressIcon) {
                     timelineUi.drawProgressBitmap(
                         canvas,
@@ -138,19 +144,19 @@ class TimelineView @JvmOverloads constructor(
                     printProgressIcon = true
                 }
 
-                val align =
-                    if (timelineUi.getTextAlign() == Paint.Align.LEFT) Paint.Align.RIGHT else Paint.Align.LEFT
                 timelineUi.printTitle(
                     canvas,
                     resources.getString(lvl.title),
                     timelineMath.getTitleXCoordinates(align),
-                    timelineMath.getTitleYCoordinates(i)
+                    timelineMath.getTitleYCoordinates(i),
+                    align
                 )
                 timelineUi.printDescription(
                     canvas,
                     resources.getString(lvl.description),
                     timelineMath.getTitleXCoordinates(align),
-                    timelineMath.getDescriptionYCoordinates(i)
+                    timelineMath.getDescriptionYCoordinates(i),
+                    align
                 )
                 timelineUi.printIcon(
                     lvl,
@@ -161,6 +167,9 @@ class TimelineView @JvmOverloads constructor(
                     timelineMath.getIconYCoordinates(i)
                 )
             }
+
+            currentSide =
+                if (currentSide == Paint.Align.LEFT) Paint.Align.RIGHT else Paint.Align.LEFT
         }
     }
 


### PR DESCRIPTION
## Summary
- Use dedicated `linePaint` and `textPaint` for drawing paths and text/icons respectively
- Track current LEFT/RIGHT side in `TimelineView` via `currentSide` variable instead of reading from paint

## Testing
- ⚠️ `./gradlew test` *(Unable to download Gradle distribution: HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d08c1502083229a06b3e223b64f0d