### PR TITLE
refactor: remove nullable text align

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUi.kt
@@ -68,7 +68,7 @@ internal class TimelineUi(
         }
     }
 
-    fun getTextAlign(): Paint.Align? {
+    fun getTextAlign(): Paint.Align {
         return pLine.textAlign
     }
 


### PR DESCRIPTION
## Summary
- make getTextAlign return non-null Paint.Align

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy (HTTP/1.1 403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_689d08c7afd88322a762ae003f2bd55e