### PR TITLE
Fix dy move naming and dynamic height calculation

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMath.kt
@@ -52,7 +52,7 @@ internal class TimelineMath(var mathConfig: TimelineMathConfig) {
                         path.rLineTo(0f, mathConfig.stepY)
                     } else {
                         path.rLineTo(horizontalStep, 0f)
-                        path.rLineTo(0f, mathConfig.getStandartDYMove(i))
+                        path.rLineTo(0f, mathConfig.getStandardDyMove(i))
                     }
                 }
 
@@ -89,7 +89,7 @@ internal class TimelineMath(var mathConfig: TimelineMathConfig) {
 
                     path.moveTo(startPositionLineXDisable, startPositionLineYDisable)
 
-                    val finishPositionLineYDisable = mathConfig.getStandartDYMove(i)
+                    val finishPositionLineYDisable = mathConfig.getStandardDyMove(i)
                     val finishPositionLineXDisable =
                         if (i % 2 == 0) -(mathConfig.getStepX() - startPositionDisableStrokeX)
                         else mathConfig.getStepX() - startPositionDisableStrokeX
@@ -100,7 +100,7 @@ internal class TimelineMath(var mathConfig: TimelineMathConfig) {
 
                 else -> {
                     path.rLineTo(horizontalStep, 0f)
-                    path.rLineTo(0f, mathConfig.getStandartDYMove(i))
+                    path.rLineTo(0f, mathConfig.getStandardDyMove(i))
                 }
             }
         }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/data/TimelineMathConfig.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/data/TimelineMathConfig.kt
@@ -63,8 +63,11 @@ data class TimelineMathConfig(
         return startPositionX
     }
 
-    /** Возвращает стандартное вертикальное смещение между шагами. Если последний шаг то высота шага делится на 2 */
-    fun getStandartDYMove(i: Int): Float {
+    /**
+     * Возвращает стандартное вертикальное смещение между шагами.
+     * Если последний шаг, то высота шага делится на 2.
+     */
+    fun getStandardDyMove(i: Int): Float {
         return if (i == steps.size - 1) stepY / 2 else stepY
     }
 
@@ -172,8 +175,12 @@ data class TimelineMathConfig(
         return offset
     }
 
+    /**
+     * Возвращает рассчитанную высоту таймлайна.
+     * Учитывает количество шагов, начальный отступ и половину размера иконки прогресса.
+     */
     fun getMeasuredHeight(): Int {
-        return ((stepY * steps.size) + stepYFirst + 50).toInt()
+        return ((stepY * steps.size) + stepYFirst + sizeIconProgress / 2f).toInt()
     }
 
     /**


### PR DESCRIPTION
## Summary
- rename `getStandartDYMove` to `getStandardDyMove`
- derive measured height using progress icon size instead of magic number

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689d08cc01c08322a11887edcd766bcd