### PR TITLE
docs: update README usage and configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,93 +6,94 @@
 
 **Using Gradle**
 
-``` gradle
+```gradle
 dependencies {
-    implementation 'com.github.dmitrypokrasov:timelineview:x.x.x'
+    implementation "com.github.dmitrypokrasov:timelineview:x.x.x"
 }
 ```
 
 ### 2. Usage
 
-* In XML Layout :
+#### In XML layout
 
-``` java
-    <com.sample.timelineview.TimeLineView
-        android:id="@+id/timeline"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:timeline_description_size="12sp"
-        app:timeline_disable_icon="@drawable/ic_tobacco_unactive"
-        app:timeline_icon_progress_size="28dp"
-        app:timeline_image_lvl_size="48dp"
-        app:timeline_margin_horizontal_image="16dp"
-        app:timeline_margin_horizontal_stroke="40dp"
-        app:timeline_margin_horizontal_text="80dp"
-        app:timeline_start_position="CENTER"
-        app:timeline_margin_top_description="4dp"
-        app:timeline_margin_top_progress_icon="6dp"
-        app:timeline_margin_top_title="52dp"
-        app:timeline_progress_icon="@drawable/ic_progress_time_line"
-        app:timeline_radius_size="48dp"
-        app:timeline_step_y_first_size="20dp"
-        app:timeline_step_y_size="80dp"
-        app:timeline_stroke_size="6dp"
-        app:timeline_title_size="12sp"
-        app:layout_constraintTop_toTopOf="parent" />
+```xml
+<com.dmitrypokrasov.timelineview.ui.TimelineView
+    android:id="@+id/timeline"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:timeline_start_position="CENTER"
+    app:timeline_progress_icon="@drawable/ic_progress_time_line"
+    app:timeline_disable_icon="@drawable/ic_tobacco_unactive" />
 ```
 
-* Configure using xml attributes or setters in code:
+#### XML attributes
 
-    <table>
-    <th>Attribute Name</th>
-    <th>Default Value</th>
-    <th>Description</th>
-    <tr>
-        <td>app:timeline_description_size="12sp"</td>
-        <td>0dp</td>
-        <td>sets description text size</td>
-    </tr>
-    </table>
+| Attribute | Description |
+|----------|-------------|
+| `app:timeline_start_position` | Start position of the timeline (`START`, `CENTER`, `END`). |
+| `app:timeline_progress_color` | Color of completed part of the stroke. |
+| `app:timeline_stroke_color` | Color of the remaining part of the stroke. |
+| `app:timeline_title_color` | Color of step titles. |
+| `app:timeline_description_color` | Color of step descriptions. |
+| `app:timeline_progress_icon` | Drawable for the current progress icon. |
+| `app:timeline_disable_icon` | Drawable for inactive step icons. |
+| `app:timeline_stroke_size` | Thickness of the stroke. |
+| `app:timeline_title_size` | Text size of step titles. |
+| `app:timeline_description_size` | Text size of step descriptions. |
+| `app:timeline_radius_size` | Corner radius of the stroke path. |
+| `app:timeline_step_y_size` | Vertical distance between steps. |
+| `app:timeline_step_y_first_size` | Top offset before the first step. |
+| `app:timeline_margin_top_title` | Top margin for titles. |
+| `app:timeline_margin_top_description` | Top margin for descriptions. |
+| `app:timeline_margin_top_progress_icon` | Top margin for progress icon. |
+| `app:timeline_margin_horizontal_image` | Horizontal margin for step icons. |
+| `app:timeline_margin_horizontal_text` | Horizontal margin for text. |
+| `app:timeline_margin_horizontal_stroke` | Horizontal margin for the vertical stroke. |
+| `app:timeline_image_lvl_size` | Size of step icons. |
+| `app:timeline_icon_progress_size` | Size of the progress icon. |
 
+#### In code
 
-* In onCreate():
+```kotlin
+import androidx.core.content.ContextCompat
+import com.dmitrypokrasov.timelineview.data.TimelineStep
+import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.ui.TimelineView
 
-``` java
+val timelineView = findViewById<TimelineView>(R.id.timeline)
 
-     val timeLineView = findViewById<TimeLineView>(R.id.timeline)
-        timeLineView.replaceLevels(
-            ArrayList(
-                listOf(
-                    TimelineLevel(
-                        title = R.string.title_1_lvl,
-                        description = R.string.description_1_9_steps,
-                        icon = R.drawable.ic_tobacco_active,
-                        count = 9,
-                        maxCount = 9
-                    ), TimelineLevel(
-                        title = R.string.title_2_lvl,
-                        description = R.string.description_10_99_steps,
-                        icon = R.drawable.ic_tobacco_active,
-                        count = 50,
-                        maxCount = 99
-                    ), TimelineLevel(
-                        title = R.string.title_3_lvl,
-                        description = R.string.description_100_999_steps,
-                        icon = R.drawable.ic_tobacco_active,
-                        maxCount = 999
-                    ), TimelineLevel(
-                        title = R.string.title_4_lvl,
-                        description = R.string.description_1000_9999_steps,
-                        icon = R.drawable.ic_tobacco_active,
-                        maxCount = 9999
-                    ), TimelineLevel(
-                        title = R.string.title_5_lvl,
-                        description = R.string.description_10000_99999_steps,
-                        icon = R.drawable.ic_tobacco_unactive,
-                        maxCount = 99999
-                    )
-                )
-            )
-        )
+val steps = listOf(
+    TimelineStep(
+        title = R.string.title_1_lvl,
+        description = R.string.description_1_9_steps,
+        icon = R.drawable.ic_tobacco_active,
+        count = 9,
+        maxCount = 9
+    ),
+    TimelineStep(
+        title = R.string.title_2_lvl,
+        description = R.string.description_10_99_steps,
+        icon = R.drawable.ic_tobacco_active,
+        count = 50,
+        maxCount = 99
+    )
+)
 
+timelineView.replaceSteps(steps)
+
+val mathConfig = TimelineMathConfig.Builder()
+    .setSteps(steps)
+    .setStartPosition(TimelineMathConfig.StartPosition.CENTER)
+    .setStepY(80f)
+    .build()
+
+val uiConfig = TimelineUiConfig.Builder()
+    .setIconProgress(R.drawable.ic_progress_time_line)
+    .setIconDisableLvl(R.drawable.ic_tobacco_unactive)
+    .setColorProgress(ContextCompat.getColor(this, R.color.purple_700))
+    .setColorStroke(ContextCompat.getColor(this, R.color.purple_200))
+    .build()
+
+timelineView.setConfig(mathConfig, uiConfig)
 ```


### PR DESCRIPTION
## Summary
- demonstrate `TimelineStep` data model and `replaceSteps` API in README examples
- document available XML attributes for `TimelineView`
- show configuration via `TimelineMathConfig.Builder` and `TimelineUiConfig.Builder`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_689d08d7c5488322a7f58bd88fd39723