### PR TITLE
feat: expose timeline engine interfaces

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineMath.kt
@@ -7,34 +7,19 @@ import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
 import kotlin.math.abs
 
 /**
- * Класс, отвечающий за расчёт координат, размеров и построение путей для отрисовки таймлайна.
- *
- * Используется при отрисовке на `Canvas` или в кастомном `View`, чтобы:
- * - построить линии прогресса (`Path`)
- * - рассчитать позиции иконок, заголовков и описаний
- * - адаптировать расположение под ширину вьюшки
- *
- * @property mathConfig Конфигурация математических параметров таймлайна.
+ * Публичная реализация [TimelineMathEngine], основанная на "змейке".
+ * Содержит всю вычислительную логику, ранее находившуюся в `TimelineMath`.
  */
-internal class TimelineMath(var mathConfig: TimelineMathConfig) {
+class SnakeTimelineMath(var mathConfig: TimelineMathConfig) : TimelineMathEngine {
 
     companion object {
-        private const val TAG = "TimelineMath"
+        private const val TAG = "SnakeTimelineMath"
     }
 
-    /**
-     * Заменяет список шагов в текущей математической конфигурации.
-     */
-    fun replaceSteps(steps: List<TimelineStep>) {
+    override fun replaceSteps(steps: List<TimelineStep>) {
         mathConfig = mathConfig.copy(steps = steps)
     }
-
-    /**
-     * Строит два пути:
-     * - [pathEnable] — линия пройденных шагов.
-     * - [pathDisable] — линия ещё не завершённых шагов.
-     */
-    fun buildPath(pathEnable: Path, pathDisable: Path) {
+    override fun buildPath(pathEnable: Path, pathDisable: Path) {
         pathDisable.reset()
         pathEnable.reset()
 
@@ -106,48 +91,34 @@ internal class TimelineMath(var mathConfig: TimelineMathConfig) {
         }
     }
 
-    fun getStartPosition(): Float {
+    override fun getStartPosition(): Float {
         return mathConfig.getStartPosition()
     }
 
-    /**
-     * Устанавливает ширину View и рассчитывает X-координату начала рисования.
-     */
-    fun setMeasuredWidth(measuredWidth: Int) {
+    override fun setMeasuredWidth(measuredWidth: Int) {
         mathConfig.setMeasuredWidth(measuredWidth)
     }
-
-    /** Возвращает горизонтальное смещение иконки прогресса на шаге [i]. */
-    fun getHorizontalIconOffset(i: Int): Float {
+    override fun getHorizontalIconOffset(i: Int): Float {
         return mathConfig.getHorizontalIconOffset(i)
     }
-
-    /** Возвращает вертикальное смещение на шаге [i]. */
-    fun getVerticalOffset(i: Int): Float {
+    override fun getVerticalOffset(i: Int): Float {
         return mathConfig.getVerticalOffset(i)
     }
 
-    fun getMeasuredHeight(): Int {
+    override fun getMeasuredHeight(): Int {
         return mathConfig.getMeasuredHeight()
     }
 
-    /** Возвращает X-координату левой границы иконки прогресса. */
-    fun getLeftCoordinates(lvl: TimelineStep): Float {
+    override fun getLeftCoordinates(lvl: TimelineStep): Float {
         return mathConfig.getLeftCoordinates(lvl)
     }
-
-    /** Возвращает Y-координату верхней границы иконки прогресса. */
-    fun getTopCoordinates(lvl: TimelineStep): Float {
+    override fun getTopCoordinates(lvl: TimelineStep): Float {
         return mathConfig.getTopCoordinates(lvl)
     }
-
-    /** Возвращает X-координату для иконки уровня. */
-    fun getIconXCoordinates(align: Paint.Align): Float {
+    override fun getIconXCoordinates(align: Paint.Align): Float {
         return mathConfig.getIconXCoordinates(align)
     }
-
-    /** Возвращает X-координату заголовка уровня. */
-    fun getTitleXCoordinates(align: Paint.Align): Float {
+    override fun getTitleXCoordinates(align: Paint.Align): Float {
         return mathConfig.getTitleXCoordinates(align)
     }
 
@@ -156,13 +127,10 @@ internal class TimelineMath(var mathConfig: TimelineMathConfig) {
         return mathConfig.getIconYCoordinates(i)
     }
 
-    /** Возвращает Y-координату заголовка уровня. */
-    fun getTitleYCoordinates(i: Int): Float {
+    override fun getTitleYCoordinates(i: Int): Float {
         return mathConfig.getTitleYCoordinates(i)
     }
-
-    /** Возвращает Y-координату описания уровня. */
-    fun getDescriptionYCoordinates(i: Int): Float {
+    override fun getDescriptionYCoordinates(i: Int): Float {
         return mathConfig.getDescriptionYCoordinates(i)
     }
 }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineUi.kt
@@ -18,11 +18,15 @@ import com.dmitrypokrasov.timelineview.data.TimelineStep
 import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
 import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
 
-internal class TimelineUi(
-    var uiConfig: TimelineUiConfig
-) {
+/**
+ * Публичная реализация [TimelineUiRenderer], использующая алгоритм "змейки",
+ * ранее находившийся в `TimelineUi`.
+ */
+class SnakeTimelineUi(
+    var uiConfig: TimelineUiConfig,
+) : TimelineUiRenderer {
     companion object {
-        private const val TAG = "TimelineUi"
+        private const val TAG = "SnakeTimelineUi"
     }
 
     /** Путь для пройденных шагов. */
@@ -49,10 +53,7 @@ internal class TimelineUi(
     /** Кисть для рисования иконок. */
     private val iconPaint = Paint()
 
-    /**
-     * Инициализирует визуальные элементы (битмапы, pathEffect).
-     */
-    fun initTools(timelineMathConfig: TimelineMathConfig, context: Context) {
+    override fun initTools(timelineMathConfig: TimelineMathConfig, context: Context) {
         Log.d(TAG, "initTools timelineUiConfig: $timelineMathConfig")
 
         pathEffect = CornerPathEffect(uiConfig.radius)
@@ -74,14 +75,14 @@ internal class TimelineUi(
         }
     }
 
-    fun resetFromPaintTools() {
+    override fun resetFromPaintTools() {
         linePaint.reset()
         linePaint.style = Paint.Style.STROKE
         linePaint.strokeWidth = uiConfig.sizeStroke
         linePaint.pathEffect = pathEffect
     }
 
-    fun resetFromTextTools() {
+    override fun resetFromTextTools() {
         textPaint.reset()
         textPaint.isAntiAlias = true
     }
@@ -91,7 +92,7 @@ internal class TimelineUi(
         iconPaint.isAntiAlias = true
     }
 
-    fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
+    override fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
         iconProgressBitmap?.let {
             canvas.drawBitmap(
                 it,
@@ -102,20 +103,17 @@ internal class TimelineUi(
         }
     }
 
-    fun drawProgressPath(canvas: Canvas) {
+    override fun drawProgressPath(canvas: Canvas) {
         linePaint.color = uiConfig.colorProgress
         canvas.drawPath(pathEnable, linePaint)
     }
 
-    fun drawDisablePath(canvas: Canvas) {
+    override fun drawDisablePath(canvas: Canvas) {
         linePaint.color = uiConfig.colorStroke
         canvas.drawPath(pathDisable, linePaint)
     }
 
-    /**
-     * Отрисовка заголовка шага.
-     */
-    fun printTitle(
+    override fun printTitle(
         canvas: Canvas,
         title: String,
         x: Float,
@@ -132,10 +130,7 @@ internal class TimelineUi(
         canvas.drawText(title, x, y, textPaint)
     }
 
-    /**
-     * Отрисовка описания шага.
-     */
-    fun printDescription(
+    override fun printDescription(
         canvas: Canvas,
         description: String,
         x: Float,
@@ -152,10 +147,7 @@ internal class TimelineUi(
         canvas.drawText(description, x, y, textPaint)
     }
 
-    /**
-     * Отрисовка иконки шага.
-     */
-    fun printIcon(
+    override fun printIcon(
         lvl: TimelineStep,
         canvas: Canvas,
         align: Paint.Align,
@@ -192,4 +184,6 @@ internal class TimelineUi(
             else -> throw IllegalArgumentException("Unsupported drawable type")
         }
     }
+
+    override fun getTextAlign(): Paint.Align = textPaint.textAlign
 }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMathEngine.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMathEngine.kt
@@ -1,0 +1,95 @@
+package com.dmitrypokrasov.timelineview.domain
+
+import android.graphics.Paint
+import android.graphics.Path
+import com.dmitrypokrasov.timelineview.data.TimelineStep
+
+/**
+ * Математический движок временной шкалы.
+ *
+ * Выполняет расчёты для построения линий прогресса и предоставляет координаты
+ * элементов интерфейса.
+ */
+interface TimelineMathEngine {
+    /**
+     * Заменяет текущий список шагов временной шкалы.
+     *
+     * После вызова все вычисления будут использовать новый набор шагов.
+     *
+     * @param steps новый список шагов
+     */
+    fun replaceSteps(steps: List<TimelineStep>)
+
+    /**
+     * Перестраивает пути для отображения прогресса.
+     *
+     * @param pathEnable путь пройденных шагов. Метод должен очистить и заполнить его заново
+     * @param pathDisable путь оставшихся шагов. Метод должен очистить и заполнить его заново
+     */
+    fun buildPath(pathEnable: Path, pathDisable: Path)
+
+    /**
+     * Возвращает X-координату точки начала рисования линии прогресса.
+     */
+    fun getStartPosition(): Float
+
+    /**
+     * Сохраняет фактическую ширину View и пересчитывает начало рисования.
+     *
+     * @param measuredWidth измеренная ширина View
+     */
+    fun setMeasuredWidth(measuredWidth: Int)
+
+    /**
+     * Возвращает горизонтальное смещение иконки прогресса для шага [i].
+     */
+    fun getHorizontalIconOffset(i: Int): Float
+
+    /**
+     * Возвращает вертикальное смещение для шага [i].
+     */
+    fun getVerticalOffset(i: Int): Float
+
+    /**
+     * Вычисляет левую координату иконки для указанного шага.
+     *
+     * @param lvl шаг временной шкалы
+     */
+    fun getLeftCoordinates(lvl: TimelineStep): Float
+
+    /**
+     * Вычисляет верхнюю координату иконки для указанного шага.
+     *
+     * @param lvl шаг временной шкалы
+     */
+    fun getTopCoordinates(lvl: TimelineStep): Float
+
+    /**
+     * Возвращает X-координату заголовка уровня в зависимости от выравнивания.
+     *
+     * @param align используемое выравнивание текста
+     */
+    fun getTitleXCoordinates(align: Paint.Align): Float
+
+    /**
+     * Возвращает X-координату иконки уровня в зависимости от выравнивания.
+     *
+     * @param align используемое выравнивание текста
+     */
+    fun getIconXCoordinates(align: Paint.Align): Float
+
+    /**
+     * Возвращает Y-координату заголовка шага [i].
+     */
+    fun getTitleYCoordinates(i: Int): Float
+
+    /**
+     * Возвращает Y-координату описания шага [i].
+     */
+    fun getDescriptionYCoordinates(i: Int): Float
+
+    /**
+     * Возвращает рассчитанную высоту View после всех вычислений.
+     */
+    fun getMeasuredHeight(): Int
+}

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUiRenderer.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUiRenderer.kt
@@ -1,0 +1,95 @@
+package com.dmitrypokrasov.timelineview.domain
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import com.dmitrypokrasov.timelineview.data.TimelineStep
+import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+
+/**
+ * Интерфейс рендерера временной шкалы.
+ *
+ * Отвечает за подготовку инструментов рисования и вывод элементов на [Canvas].
+ */
+interface TimelineUiRenderer {
+    /**
+     * Инициализирует визуальные инструменты.
+     *
+     * Загружает и подготавливает ресурсы (иконки, эффекты линий) на основе
+     * параметров математики и контекста приложения.
+     *
+     * @param timelineMathConfig конфигурация размеров и отступов
+     * @param context Android контекст для доступа к ресурсам
+     */
+    fun initTools(timelineMathConfig: TimelineMathConfig, context: Context)
+
+    /**
+     * Сбрасывает и настраивает кисть для рисования линий.
+     */
+    fun resetFromPaintTools()
+
+    /**
+     * Сбрасывает и настраивает кисть для рисования текста.
+     */
+    fun resetFromTextTools()
+
+    /**
+     * Рисует bitmap текущего прогресса.
+     *
+     * @param canvas холст, на котором ведётся рисование
+     * @param leftCoordinates левая координата вывода
+     * @param topCoordinates верхняя координата вывода
+     */
+    fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float)
+
+    /**
+     * Рисует путь пройденных шагов.
+     */
+    fun drawProgressPath(canvas: Canvas)
+
+    /**
+     * Рисует путь непройденных шагов.
+     */
+    fun drawDisablePath(canvas: Canvas)
+
+    /**
+     * Печатает заголовок шага.
+     *
+     * @param canvas холст для рисования
+     * @param title текст заголовка
+     * @param x X-координата текста
+     * @param y Y-координата текста
+     * @param align выравнивание текста
+     */
+    fun printTitle(canvas: Canvas, title: String, x: Float, y: Float, align: Paint.Align)
+
+    /**
+     * Печатает описание шага.
+     *
+     * @param canvas холст для рисования
+     * @param description текст описания
+     * @param x X-координата текста
+     * @param y Y-координата текста
+     * @param align выравнивание текста
+     */
+    fun printDescription(canvas: Canvas, description: String, x: Float, y: Float, align: Paint.Align)
+
+    /**
+     * Рисует иконку шага.
+     *
+     * В зависимости от состояния шага выбирает соответствующий ресурс.
+     *
+     * @param lvl данные шага
+     * @param canvas холст для рисования
+     * @param align выравнивание иконки
+     * @param context Android контекст для получения ресурсов
+     * @param x X-координата иконки
+     * @param y Y-координата иконки
+     */
+    fun printIcon(lvl: TimelineStep, canvas: Canvas, align: Paint.Align, context: Context, x: Float, y: Float)
+
+    /**
+     * Возвращает текущее выравнивание текста, используемое кистью.
+     */
+    fun getTextAlign(): Paint.Align
+}

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineView.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineView.kt
@@ -7,8 +7,8 @@ import android.util.AttributeSet
 import android.util.Log
 import android.view.View
 import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.TimelineMath
-import com.dmitrypokrasov.timelineview.domain.TimelineUi
+import com.dmitrypokrasov.timelineview.domain.SnakeTimelineMath
+import com.dmitrypokrasov.timelineview.domain.SnakeTimelineUi
 import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
 import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
 
@@ -26,7 +26,7 @@ import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
  * - иконку текущего шага (progress icon)
  * - заголовки и описания
  *
- * Использует [TimelineMath] как движок для всех вычислений и генерации координат.
+ * Использует [SnakeTimelineMath] как движок для всех вычислений и генерации координат.
  *
  * @constructor Создаёт [TimelineView], читая параметры из XML или по умолчанию.
  */
@@ -41,18 +41,18 @@ class TimelineView @JvmOverloads constructor(
     }
 
     /** Математическая конфигурация таймлайна. */
-    private var timelineMath: TimelineMath
+    private var timelineMath: SnakeTimelineMath
 
     /** Визуальная конфигурация таймлайна. */
-    private var timelineUi: TimelineUi
+    private var timelineUi: SnakeTimelineUi
 
     /** Текущая сторона отрисовки (LEFT/RIGHT). */
     private var currentSide: Paint.Align = Paint.Align.RIGHT
 
     init {
         val (mathConfig, uiConfig) = ConfigParser(context).parse(attrs)
-        timelineMath = TimelineMath(mathConfig)
-        timelineUi = TimelineUi(uiConfig)
+        timelineMath = SnakeTimelineMath(mathConfig)
+        timelineUi = SnakeTimelineUi(uiConfig)
         initTools(mathConfig, uiConfig)
     }
 
@@ -70,8 +70,8 @@ class TimelineView @JvmOverloads constructor(
     fun setConfig(timelineMathConfig: TimelineMathConfig, timelineUiConfig: TimelineUiConfig) {
         if (timelineMath.mathConfig == timelineMathConfig && timelineUi.uiConfig == timelineUiConfig) return
 
-        timelineMath = TimelineMath(timelineMathConfig)
-        timelineUi = TimelineUi(timelineUiConfig)
+        timelineMath = SnakeTimelineMath(timelineMathConfig)
+        timelineUi = SnakeTimelineUi(timelineUiConfig)
 
         initTools(timelineMathConfig, timelineUiConfig)
 


### PR DESCRIPTION
## Summary
- move KDocs to TimelineMathEngine and TimelineUiRenderer interfaces with detailed Russian descriptions
- translate SnakeTimelineMath and SnakeTimelineUi class comments and remove duplicate method docs

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689dc78d963c83229f8115fad24992f4