### PR TITLE
Add linear timeline with orientation support

### DIFF
--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineMath.kt
@@ -1,0 +1,116 @@
+package com.dmitrypokrasov.timelineview.domain
+
+import android.graphics.Paint
+import android.graphics.Path
+import com.dmitrypokrasov.timelineview.data.TimelineStep
+import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+
+/**
+ * Простая реализация [TimelineMathEngine], строящая путь без
+ * чередования сторон. Линия может располагаться вертикально или
+ * горизонтально в зависимости от [orientation].
+ */
+class LinearTimelineMath(
+    var mathConfig: TimelineMathConfig,
+    val orientation: Orientation = Orientation.VERTICAL,
+) : TimelineMathEngine {
+
+    /** Возможные направления построения линии. */
+    enum class Orientation { VERTICAL, HORIZONTAL }
+
+    override fun replaceSteps(steps: List<TimelineStep>) {
+        mathConfig = mathConfig.copy(steps = steps)
+    }
+
+    override fun buildPath(pathEnable: Path, pathDisable: Path) {
+        pathEnable.reset()
+        pathDisable.reset()
+
+        var x = 0f
+        var y = 0f
+        pathEnable.moveTo(x, y)
+        pathDisable.moveTo(x, y)
+
+        var drawEnable = true
+
+        mathConfig.steps.forEachIndexed { index, step ->
+            val segment = if (orientation == Orientation.VERTICAL) {
+                if (index == 0) mathConfig.stepYFirst else mathConfig.getStandardDyMove(index)
+            } else {
+                if (index == 0) mathConfig.getStepXFirst() else mathConfig.getStepX()
+            }
+
+            if (drawEnable) {
+                val progress = segment * step.percents / 100f
+                if (orientation == Orientation.VERTICAL) {
+                    pathEnable.rLineTo(0f, progress)
+                    if (progress < segment) {
+                        pathDisable.moveTo(x, y + progress)
+                        pathDisable.rLineTo(0f, segment - progress)
+                        drawEnable = false
+                    }
+                    y += segment
+                } else {
+                    pathEnable.rLineTo(progress, 0f)
+                    if (progress < segment) {
+                        pathDisable.moveTo(x + progress, y)
+                        pathDisable.rLineTo(segment - progress, 0f)
+                        drawEnable = false
+                    }
+                    x += segment
+                }
+            } else {
+                if (orientation == Orientation.VERTICAL) {
+                    pathDisable.rLineTo(0f, segment)
+                    y += segment
+                } else {
+                    pathDisable.rLineTo(segment, 0f)
+                    x += segment
+                }
+            }
+        }
+    }
+
+    override fun getStartPosition(): Float = mathConfig.getStartPosition()
+
+    override fun setMeasuredWidth(measuredWidth: Int) {
+        mathConfig.setMeasuredWidth(measuredWidth)
+    }
+
+    override fun getHorizontalIconOffset(i: Int): Float {
+        return if (orientation == Orientation.VERTICAL) -mathConfig.sizeIconProgress / 2f
+        else mathConfig.getVerticalOffset(i)
+    }
+
+    override fun getVerticalOffset(i: Int): Float {
+        return if (orientation == Orientation.VERTICAL) mathConfig.getVerticalOffset(i)
+        else -mathConfig.sizeIconProgress / 2f
+    }
+
+    override fun getMeasuredHeight(): Int = mathConfig.getMeasuredHeight()
+
+    override fun getLeftCoordinates(lvl: TimelineStep): Float {
+        return -mathConfig.sizeIconProgress / 2f
+    }
+
+    override fun getTopCoordinates(lvl: TimelineStep): Float {
+        return -mathConfig.sizeIconProgress / 2f
+    }
+
+    override fun getTitleXCoordinates(align: Paint.Align): Float {
+        return mathConfig.getTitleXCoordinates(align)
+    }
+
+    override fun getIconXCoordinates(align: Paint.Align): Float {
+        return mathConfig.getIconXCoordinates(align)
+    }
+
+    override fun getTitleYCoordinates(i: Int): Float {
+        return mathConfig.getTitleYCoordinates(i)
+    }
+
+    override fun getDescriptionYCoordinates(i: Int): Float {
+        return mathConfig.getDescriptionYCoordinates(i)
+    }
+}
+

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineUi.kt
@@ -1,0 +1,181 @@
+package com.dmitrypokrasov.timelineview.domain
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.CornerPathEffect
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Typeface
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.VectorDrawable
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.scale
+import com.dmitrypokrasov.timelineview.data.TimelineStep
+import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+
+/**
+ * Реализация [TimelineUiRenderer] для линейного таймлайна. Отрисовывает
+ * прямую линию и элементы шагов.
+ */
+class LinearTimelineUi(
+    var uiConfig: TimelineUiConfig,
+) : TimelineUiRenderer {
+
+    /** Путь для пройденных шагов. */
+    val pathEnable = Path()
+
+    /** Путь для непройденных шагов. */
+    val pathDisable = Path()
+
+    /** Битмап неактивного шага. */
+    private var iconDisableStep: Bitmap? = null
+
+    /** Скругление углов линии пути. */
+    private var pathEffect: CornerPathEffect? = null
+
+    /** Битмап текущей иконки прогресса. */
+    private var iconProgressBitmap: Bitmap? = null
+
+    /** Кисть для рисования линий. */
+    private val linePaint = Paint()
+
+    /** Кисть для рисования текста. */
+    private val textPaint = Paint()
+
+    /** Кисть для рисования иконок. */
+    private val iconPaint = Paint()
+
+    override fun initTools(timelineMathConfig: TimelineMathConfig, context: Context) {
+        pathEffect = CornerPathEffect(uiConfig.radius)
+
+        getBitmap(uiConfig.iconDisableLvl, context)?.let { bitmap ->
+            iconDisableStep = bitmap.scale(
+                timelineMathConfig.sizeImageLvl.toInt(),
+                timelineMathConfig.sizeImageLvl.toInt(),
+                false
+            )
+        }
+
+        getBitmap(uiConfig.iconProgress, context)?.let { bitmap ->
+            iconProgressBitmap = bitmap.scale(
+                timelineMathConfig.sizeIconProgress.toInt(),
+                timelineMathConfig.sizeIconProgress.toInt(),
+                false
+            )
+        }
+    }
+
+    override fun resetFromPaintTools() {
+        linePaint.reset()
+        linePaint.style = Paint.Style.STROKE
+        linePaint.strokeWidth = uiConfig.sizeStroke
+        linePaint.pathEffect = pathEffect
+    }
+
+    override fun resetFromTextTools() {
+        textPaint.reset()
+        textPaint.isAntiAlias = true
+    }
+
+    fun resetFromIconTools() {
+        iconPaint.reset()
+        iconPaint.isAntiAlias = true
+    }
+
+    override fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
+        iconProgressBitmap?.let {
+            canvas.drawBitmap(
+                it,
+                leftCoordinates,
+                topCoordinates,
+                iconPaint
+            )
+        }
+    }
+
+    override fun drawProgressPath(canvas: Canvas) {
+        linePaint.color = uiConfig.colorProgress
+        canvas.drawPath(pathEnable, linePaint)
+    }
+
+    override fun drawDisablePath(canvas: Canvas) {
+        linePaint.color = uiConfig.colorStroke
+        canvas.drawPath(pathDisable, linePaint)
+    }
+
+    override fun printTitle(
+        canvas: Canvas,
+        title: String,
+        x: Float,
+        y: Float,
+        align: Paint.Align
+    ) {
+        textPaint.apply {
+            textAlign = align
+            textSize = uiConfig.sizeTitle
+            typeface = Typeface.DEFAULT_BOLD
+            color = uiConfig.colorTitle
+        }
+
+        canvas.drawText(title, x, y, textPaint)
+    }
+
+    override fun printDescription(
+        canvas: Canvas,
+        description: String,
+        x: Float,
+        y: Float,
+        align: Paint.Align
+    ) {
+        textPaint.apply {
+            textAlign = align
+            textSize = uiConfig.sizeDescription
+            typeface = Typeface.DEFAULT
+            color = uiConfig.colorDescription
+        }
+
+        canvas.drawText(description, x, y, textPaint)
+    }
+
+    override fun printIcon(
+        lvl: TimelineStep,
+        canvas: Canvas,
+        align: Paint.Align,
+        context: Context,
+        x: Float,
+        y: Float
+    ) {
+        val bm: Bitmap? = when {
+            lvl.count == lvl.maxCount && lvl.icon != 0 -> getBitmap(lvl.icon, context)
+            else -> iconDisableStep
+        }
+        bm?.let {
+            iconPaint.textAlign = align
+            canvas.drawBitmap(it, x, y, iconPaint)
+        }
+    }
+
+    private fun getBitmap(drawableId: Int, context: Context): Bitmap? {
+        if (drawableId == 0) return null
+
+        return when (val drawable = ContextCompat.getDrawable(context, drawableId)) {
+            is BitmapDrawable -> BitmapFactory.decodeResource(context.resources, drawableId)
+            is VectorDrawable -> {
+                val bitmap = createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight)
+                val canvas = Canvas(bitmap)
+                drawable.setBounds(0, 0, canvas.width, canvas.height)
+                drawable.draw(canvas)
+                bitmap
+            }
+
+            else -> throw IllegalArgumentException("Unsupported drawable type")
+        }
+    }
+
+    override fun getTextAlign(): Paint.Align = textPaint.textAlign
+}
+


### PR DESCRIPTION
## Summary
- add LinearTimelineMath to compute straight timeline coordinates with vertical and horizontal orientations
- add LinearTimelineUi to render a simple line and icons

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689dd17a141483228f817c17879dd51e