### PR TITLE
feat: support orientation-driven timeline engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,17 @@ val uiConfig = TimelineUiConfig.Builder()
 
 timelineView.setConfig(mathConfig, uiConfig)
 ```
+
+### Custom engines
+
+If default linear or snake behaviours do not cover your case, provide your own
+implementations of `TimelineMathEngine` and `TimelineUiRenderer`:
+
+```kotlin
+timelineView.setConfig(
+    mathConfig,
+    uiConfig,
+    mathEngine = MyMathEngine(mathConfig),
+    uiRenderer = MyUiRenderer(uiConfig)
+)
+```

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineMath.kt
@@ -112,5 +112,10 @@ class LinearTimelineMath(
     override fun getDescriptionYCoordinates(i: Int): Float {
         return mathConfig.getDescriptionYCoordinates(i)
     }
+
+    override fun getIconYCoordinates(i: Int): Float {
+        return if (orientation == Orientation.VERTICAL) mathConfig.getIconYCoordinates(i)
+        else -mathConfig.sizeImageLvl / 2f
+    }
 }
 

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/LinearTimelineUi.kt
@@ -26,10 +26,10 @@ class LinearTimelineUi(
 ) : TimelineUiRenderer {
 
     /** Путь для пройденных шагов. */
-    val pathEnable = Path()
+    override val pathEnable = Path()
 
     /** Путь для непройденных шагов. */
-    val pathDisable = Path()
+    override val pathDisable = Path()
 
     /** Битмап неактивного шага. */
     private var iconDisableStep: Bitmap? = null
@@ -81,7 +81,7 @@ class LinearTimelineUi(
         textPaint.isAntiAlias = true
     }
 
-    fun resetFromIconTools() {
+    override fun resetFromIconTools() {
         iconPaint.reset()
         iconPaint.isAntiAlias = true
     }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineMath.kt
@@ -123,7 +123,7 @@ class SnakeTimelineMath(var mathConfig: TimelineMathConfig) : TimelineMathEngine
     }
 
     /** Возвращает Y-координату для иконки уровня. */
-    fun getIconYCoordinates(i: Int): Float {
+    override fun getIconYCoordinates(i: Int): Float {
         return mathConfig.getIconYCoordinates(i)
     }
 

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/SnakeTimelineUi.kt
@@ -30,10 +30,10 @@ class SnakeTimelineUi(
     }
 
     /** Путь для пройденных шагов. */
-    val pathEnable = Path()
+    override val pathEnable = Path()
 
     /** Путь для непройденных шагов. */
-    val pathDisable = Path()
+    override val pathDisable = Path()
 
     /** Битмап неактивного шага. */
     private var iconDisableStep: Bitmap? = null
@@ -87,7 +87,7 @@ class SnakeTimelineUi(
         textPaint.isAntiAlias = true
     }
 
-    fun resetFromIconTools() {
+    override fun resetFromIconTools() {
         iconPaint.reset()
         iconPaint.isAntiAlias = true
     }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMathEngine.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineMathEngine.kt
@@ -89,6 +89,11 @@ interface TimelineMathEngine {
     fun getDescriptionYCoordinates(i: Int): Float
 
     /**
+     * Возвращает Y-координату иконки шага [i].
+     */
+    fun getIconYCoordinates(i: Int): Float
+
+    /**
      * Возвращает рассчитанную высоту View после всех вычислений.
      */
     fun getMeasuredHeight(): Int

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUiRenderer.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/domain/TimelineUiRenderer.kt
@@ -3,6 +3,7 @@ package com.dmitrypokrasov.timelineview.domain
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
+import android.graphics.Path
 import com.dmitrypokrasov.timelineview.data.TimelineStep
 import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
 
@@ -12,6 +13,11 @@ import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
  * Отвечает за подготовку инструментов рисования и вывод элементов на [Canvas].
  */
 interface TimelineUiRenderer {
+    /** Путь для пройденных шагов. */
+    val pathEnable: Path
+
+    /** Путь для непройденных шагов. */
+    val pathDisable: Path
     /**
      * Инициализирует визуальные инструменты.
      *
@@ -32,6 +38,11 @@ interface TimelineUiRenderer {
      * Сбрасывает и настраивает кисть для рисования текста.
      */
     fun resetFromTextTools()
+
+    /**
+      * Сбрасывает и настраивает кисть для рисования иконок.
+      */
+    fun resetFromIconTools()
 
     /**
      * Рисует bitmap текущего прогресса.

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/ConfigParser.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/ConfigParser.kt
@@ -8,6 +8,7 @@ import com.dmitrypokrasov.timelineview.R
 import com.dmitrypokrasov.timelineview.data.TimelineConstants
 import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
 import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.ui.TimelineOrientation
 
 /**
  * Utility class for parsing view attributes into math and UI configurations.
@@ -15,7 +16,7 @@ import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
 class ConfigParser(private val context: Context) {
 
     @SuppressLint("CustomViewStyleable")
-    fun parse(attrs: AttributeSet?): Pair<TimelineMathConfig, TimelineUiConfig> {
+    fun parse(attrs: AttributeSet?): Triple<TimelineMathConfig, TimelineUiConfig, TimelineOrientation> {
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.TimelineView)
 
         val mathBuilder = TimelineMathConfig.Builder()
@@ -142,9 +143,14 @@ class ConfigParser(private val context: Context) {
                 typedArray.getResourceId(R.styleable.TimelineView_timeline_progress_icon, 0)
             )
 
+        val orientation = TimelineOrientation.entries[typedArray.getInt(
+            R.styleable.TimelineView_timeline_orientation,
+            TimelineOrientation.SNAKE_VERTICAL.ordinal
+        )]
+
         typedArray.recycle()
 
-        return mathBuilder.build() to uiBuilder.build()
+        return Triple(mathBuilder.build(), uiBuilder.build(), orientation)
     }
 }
 

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineOrientation.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineOrientation.kt
@@ -1,0 +1,15 @@
+package com.dmitrypokrasov.timelineview.ui
+
+/**
+ * Orientation modes for [TimelineView].
+ *
+ * - [SNAKE_VERTICAL] uses snake-like rendering in vertical direction.
+ * - [LINEAR_VERTICAL] draws a simple linear vertical timeline.
+ * - [LINEAR_HORIZONTAL] draws a simple linear horizontal timeline.
+ */
+enum class TimelineOrientation {
+    SNAKE_VERTICAL,
+    LINEAR_VERTICAL,
+    LINEAR_HORIZONTAL;
+}
+

--- a/timelineview/src/main/res/values/attrs.xml
+++ b/timelineview/src/main/res/values/attrs.xml
@@ -6,6 +6,11 @@
             <enum name="CENTER" value="1" />
             <enum name="END" value="2" />
         </attr>
+        <attr name="timeline_orientation" format="enum">
+            <enum name="SNAKE_VERTICAL" value="0" />
+            <enum name="LINEAR_VERTICAL" value="1" />
+            <enum name="LINEAR_HORIZONTAL" value="2" />
+        </attr>
         <attr name="timeline_progress_color" format="color" />
         <attr name="timeline_stroke_color" format="color" />
         <attr name="timeline_title_color" format="color" />


### PR DESCRIPTION
## Summary
- add `timeline_orientation` XML attribute and `TimelineOrientation` enum
- switch `TimelineView` to `TimelineMathEngine`/`TimelineUiRenderer` interfaces
- select linear or snake engines based on orientation and delegate drawing through interfaces
- allow injecting custom math/UI engines via optional arguments in `setConfig`

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689dd3b436288322aa51afb771c993e0