### PR TITLE
refactor: reorganize timeline packages and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ You can also provide custom math and UI engines. The example below shows a linea
 
 ```kotlin
 import androidx.core.content.ContextCompat
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.LinearTimelineMath
-import com.dmitrypokrasov.timelineview.domain.LinearTimelineUi
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
-import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.math.LinearTimelineMath
+import com.dmitrypokrasov.timelineview.render.LinearTimelineUi
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.config.TimelineUiConfig
 import com.dmitrypokrasov.timelineview.ui.TimelineView
 
 val timelineView = findViewById<TimelineView>(R.id.timeline)

--- a/app/src/main/java/com/dmitrypokrasov/timeline/MainActivity.kt
+++ b/app/src/main/java/com/dmitrypokrasov/timeline/MainActivity.kt
@@ -3,11 +3,11 @@ package com.dmitrypokrasov.timeline
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.SnakeTimelineMath
-import com.dmitrypokrasov.timelineview.domain.SnakeTimelineUi
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
-import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.math.SnakeTimelineMath
+import com.dmitrypokrasov.timelineview.render.SnakeTimelineUi
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.config.TimelineUiConfig
 import com.dmitrypokrasov.timelineview.ui.TimelineView
 
 class MainActivity : AppCompatActivity() {

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineConfig.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineConfig.kt
@@ -1,0 +1,12 @@
+package com.dmitrypokrasov.timelineview.config
+
+/**
+ * Aggregates math and UI configurations for the timeline view.
+ *
+ * @property math configuration for sizes and positioning.
+ * @property ui configuration for visual appearance.
+ */
+data class TimelineConfig(
+    val math: TimelineMathConfig,
+    val ui: TimelineUiConfig
+)

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineConfigParser.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineConfigParser.kt
@@ -1,21 +1,19 @@
-package com.dmitrypokrasov.timelineview.ui
+package com.dmitrypokrasov.timelineview.config
 
 import android.annotation.SuppressLint
 import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.ContextCompat
 import com.dmitrypokrasov.timelineview.R
-import com.dmitrypokrasov.timelineview.data.TimelineConstants
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
-import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.model.TimelineConstants
 
 /**
- * Utility class for parsing view attributes into math and UI configurations.
+ * Utility class for parsing view attributes into a [TimelineConfig].
  */
-class ConfigParser(private val context: Context) {
+class TimelineConfigParser(private val context: Context) {
 
     @SuppressLint("CustomViewStyleable")
-    fun parse(attrs: AttributeSet?): Pair<TimelineMathConfig, TimelineUiConfig> {
+    fun parse(attrs: AttributeSet?): TimelineConfig {
         val typedArray = context.obtainStyledAttributes(attrs, R.styleable.TimelineView)
 
         val mathConfig = TimelineMathConfig(
@@ -110,7 +108,7 @@ class ConfigParser(private val context: Context) {
 
         typedArray.recycle()
 
-        return mathConfig to uiConfig
+        return TimelineConfig(mathConfig, uiConfig)
     }
 }
 

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineMathConfig.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineMathConfig.kt
@@ -1,7 +1,7 @@
-package com.dmitrypokrasov.timelineview.domain.data
+package com.dmitrypokrasov.timelineview.config
 
-import com.dmitrypokrasov.timelineview.data.TimelineConstants
-import com.dmitrypokrasov.timelineview.data.TimelineStep
+import com.dmitrypokrasov.timelineview.model.TimelineConstants
+import com.dmitrypokrasov.timelineview.model.TimelineStep
 
 /**
  * Конфигурация параметров позиционирования и размеров таймлайна.
@@ -20,7 +20,7 @@ import com.dmitrypokrasov.timelineview.data.TimelineStep
  * @property sizeImageLvl размер иконок шагов
  *
  * Хранит только данные без дополнительных вычислений. Вся логика расчётов
- * вынесена в реализации [com.dmitrypokrasov.timelineview.domain.TimelineMathEngine].
+ * вынесена в реализации [com.dmitrypokrasov.timelineview.math.TimelineMathEngine].
  */
 data class TimelineMathConfig(
     val startPosition: StartPosition = StartPosition.CENTER,

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineUiConfig.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/config/TimelineUiConfig.kt
@@ -1,8 +1,8 @@
-package com.dmitrypokrasov.timelineview.domain.data
+package com.dmitrypokrasov.timelineview.config
 
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
-import com.dmitrypokrasov.timelineview.data.TimelineConstants
+import com.dmitrypokrasov.timelineview.model.TimelineConstants
 
 /**
  * Конфигурация визуального оформления элементов таймлайна.
@@ -19,7 +19,7 @@ import com.dmitrypokrasov.timelineview.data.TimelineConstants
  * @property sizeStroke толщина линии
  *
  * Содержит только значения, используемые рендерерами. Вся логика подготовки
- * вынесена в реализации [com.dmitrypokrasov.timelineview.domain.TimelineUiRenderer].
+ * вынесена в реализации [com.dmitrypokrasov.timelineview.render.TimelineUiRenderer].
  */
 data class TimelineUiConfig(
     @DrawableRes val iconDisableLvl: Int = 0,

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMath.kt
@@ -1,9 +1,9 @@
-package com.dmitrypokrasov.timelineview.domain
+package com.dmitrypokrasov.timelineview.math
 
 import android.graphics.Paint
 import android.graphics.Path
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
 
 /**
  * Простая реализация [TimelineMathEngine], строящая путь без чередования сторон.
@@ -109,9 +109,9 @@ class LinearTimelineMath(
         ((mathConfig.stepY * mathConfig.steps.size) +
             mathConfig.stepYFirst + mathConfig.sizeIconProgress / 2f).toInt()
 
-    override fun getLeftCoordinates(lvl: TimelineStep): Float = -mathConfig.sizeIconProgress / 2f
+    override fun getLeftCoordinates(step: TimelineStep): Float = -mathConfig.sizeIconProgress / 2f
 
-    override fun getTopCoordinates(lvl: TimelineStep): Float = -mathConfig.sizeIconProgress / 2f
+    override fun getTopCoordinates(step: TimelineStep): Float = -mathConfig.sizeIconProgress / 2f
 
     override fun getTitleXCoordinates(align: Paint.Align): Float {
         val stepX = getStepX()

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/SnakeTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/SnakeTimelineMath.kt
@@ -1,9 +1,9 @@
-package com.dmitrypokrasov.timelineview.domain
+package com.dmitrypokrasov.timelineview.math
 
 import android.graphics.Paint
 import android.graphics.Path
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
 import kotlin.math.abs
 
 /**
@@ -33,11 +33,11 @@ class SnakeTimelineMath(private var mathConfig: TimelineMathConfig) : TimelineMa
         var enable = mathConfig.steps.isNotEmpty() && mathConfig.steps[0].count != 0
         var path: Path = if (enable) pathEnable else pathDisable
 
-        mathConfig.steps.forEachIndexed { i, lvl ->
+        mathConfig.steps.forEachIndexed { i, step ->
             var horizontalStep = if (i % 2 == 0) -getStepX() else getStepX()
 
             when {
-                lvl.percents == 100 -> {
+                step.percents == 100 -> {
                     if (i == 0) {
                         path.rLineTo(0f, mathConfig.stepYFirst)
                         path.rLineTo(-getStepXFirst(), 0f)
@@ -50,7 +50,7 @@ class SnakeTimelineMath(private var mathConfig: TimelineMathConfig) : TimelineMa
 
                 i == 0 -> {
                     path.rLineTo(0f, mathConfig.stepYFirst)
-                    val startPosDisable = calculateStartPositionDisableStrokeX(lvl, i)
+                    val startPosDisable = calculateStartPositionDisableStrokeX(step, i)
 
                     if (enable) {
                         path.rLineTo(-startPosDisable, 0f)
@@ -63,7 +63,7 @@ class SnakeTimelineMath(private var mathConfig: TimelineMathConfig) : TimelineMa
                 }
 
                 enable -> {
-                    val startPosDisable = calculateStartPositionDisableStrokeX(lvl, i)
+                    val startPosDisable = calculateStartPositionDisableStrokeX(step, i)
 
                     horizontalStep = if (i % 2 == 0) -getStepX() else getStepX()
                     val finishPositionLineXEnable =
@@ -118,12 +118,12 @@ class SnakeTimelineMath(private var mathConfig: TimelineMathConfig) : TimelineMa
         ((mathConfig.stepY * mathConfig.steps.size) +
             mathConfig.stepYFirst + mathConfig.sizeIconProgress / 2f).toInt()
 
-    override fun getLeftCoordinates(lvl: TimelineStep): Float =
-        if (lvl.count == 0) -mathConfig.sizeIconProgress / 2f
+    override fun getLeftCoordinates(step: TimelineStep): Float =
+        if (step.count == 0) -mathConfig.sizeIconProgress / 2f
         else -startPositionDisableStrokeX - mathConfig.sizeIconProgress / 2f
 
-    override fun getTopCoordinates(lvl: TimelineStep): Float =
-        if (lvl.count == 0) -mathConfig.sizeIconProgress / 2f
+    override fun getTopCoordinates(step: TimelineStep): Float =
+        if (step.count == 0) -mathConfig.sizeIconProgress / 2f
         else mathConfig.stepYFirst - mathConfig.sizeIconProgress / 2f
 
     override fun getIconXCoordinates(align: Paint.Align): Float {
@@ -164,9 +164,9 @@ class SnakeTimelineMath(private var mathConfig: TimelineMathConfig) : TimelineMa
     private fun calculateTitleYCoordinates(i: Int): Float =
         (mathConfig.stepY * i) + mathConfig.marginTopTitle
 
-    private fun calculateStartPositionDisableStrokeX(lvl: TimelineStep, i: Int): Float {
+    private fun calculateStartPositionDisableStrokeX(step: TimelineStep, i: Int): Float {
         val startPosition =
-            if (i == 0) getStepXFirst() / 100 * lvl.percents else getStepX() / 100 * lvl.percents
+            if (i == 0) getStepXFirst() / 100 * step.percents else getStepX() / 100 * step.percents
         startPositionDisableStrokeX = startPosition
         return startPosition
     }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/TimelineMathEngine.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/TimelineMathEngine.kt
@@ -1,9 +1,9 @@
-package com.dmitrypokrasov.timelineview.domain
+package com.dmitrypokrasov.timelineview.math
 
 import android.graphics.Paint
 import android.graphics.Path
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
 
 /**
  * Математический движок временной шкалы.
@@ -63,16 +63,16 @@ interface TimelineMathEngine {
     /**
      * Вычисляет левую координату иконки для указанного шага.
      *
-     * @param lvl шаг временной шкалы
+     * @param step шаг временной шкалы
      */
-    fun getLeftCoordinates(lvl: TimelineStep): Float
+    fun getLeftCoordinates(step: TimelineStep): Float
 
     /**
      * Вычисляет верхнюю координату иконки для указанного шага.
      *
-     * @param lvl шаг временной шкалы
+     * @param step шаг временной шкалы
      */
-    fun getTopCoordinates(lvl: TimelineStep): Float
+    fun getTopCoordinates(step: TimelineStep): Float
 
     /** Возвращает Y-координату иконки шага [i]. */
     fun getIconYCoordinates(i: Int): Float

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/model/TimelineConstants.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/model/TimelineConstants.kt
@@ -1,8 +1,11 @@
-package com.dmitrypokrasov.timelineview.data
+package com.dmitrypokrasov.timelineview.model
 
 import androidx.annotation.ColorRes
 import com.google.android.material.R.color
 
+/**
+ * Contains default values for timeline configuration.
+ */
 internal object TimelineConstants {
     const val DEFAULT_STEP_Y_SIZE = 150f
     const val DEFAULT_RADIUS_SIZE = 0f

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/model/TimelineStep.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/model/TimelineStep.kt
@@ -1,4 +1,4 @@
-package com.dmitrypokrasov.timelineview.data
+package com.dmitrypokrasov.timelineview.model
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/render/SnakeTimelineUi.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/render/SnakeTimelineUi.kt
@@ -1,4 +1,4 @@
-package com.dmitrypokrasov.timelineview.domain
+package com.dmitrypokrasov.timelineview.render
 
 import android.content.Context
 import android.graphics.Bitmap
@@ -10,20 +10,24 @@ import android.graphics.Path
 import android.graphics.Typeface
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.VectorDrawable
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.scale
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
-import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.config.TimelineUiConfig
 
 /**
- * Реализация [TimelineUiRenderer] для линейного таймлайна. Отрисовывает
- * прямую линию и элементы шагов.
+ * Публичная реализация [TimelineUiRenderer], использующая алгоритм "змейки",
+ * ранее находившийся в `TimelineUi`.
  */
-class LinearTimelineUi(
+class SnakeTimelineUi(
     private var uiConfig: TimelineUiConfig,
 ) : TimelineUiRenderer {
+    companion object {
+        private const val TAG = "SnakeTimelineUi"
+    }
 
     /** Путь для пройденных шагов. */
     private val pathEnable = Path()
@@ -50,6 +54,8 @@ class LinearTimelineUi(
     private val iconPaint = Paint()
 
     override fun initTools(timelineMathConfig: TimelineMathConfig, context: Context) {
+        Log.d(TAG, "initTools timelineUiConfig: $timelineMathConfig")
+
         pathEffect = CornerPathEffect(uiConfig.radius)
 
         getBitmap(uiConfig.iconDisableLvl, context)?.let { bitmap ->
@@ -69,14 +75,14 @@ class LinearTimelineUi(
         }
     }
 
-    override fun resetFromPaintTools() {
+    override fun prepareStrokePaint() {
         linePaint.reset()
         linePaint.style = Paint.Style.STROKE
         linePaint.strokeWidth = uiConfig.sizeStroke
         linePaint.pathEffect = pathEffect
     }
 
-    override fun resetFromTextTools() {
+    override fun prepareTextPaint() {
         textPaint.reset()
         textPaint.isAntiAlias = true
     }
@@ -87,12 +93,12 @@ class LinearTimelineUi(
 
     override fun getConfig(): TimelineUiConfig = uiConfig
 
-    override fun resetFromIconTools() {
+    override fun prepareIconPaint() {
         iconPaint.reset()
         iconPaint.isAntiAlias = true
     }
 
-    override fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
+    override fun drawProgressIcon(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float) {
         iconProgressBitmap?.let {
             canvas.drawBitmap(
                 it,
@@ -103,21 +109,21 @@ class LinearTimelineUi(
         }
     }
 
-    override fun drawProgressPath(canvas: Canvas) {
+    override fun drawCompletedPath(canvas: Canvas) {
         linePaint.color = uiConfig.colorProgress
         canvas.drawPath(pathEnable, linePaint)
     }
 
-    override fun drawDisablePath(canvas: Canvas) {
+    override fun drawRemainingPath(canvas: Canvas) {
         linePaint.color = uiConfig.colorStroke
         canvas.drawPath(pathDisable, linePaint)
     }
 
-    override fun getPathEnable(): Path = pathEnable
+    override fun getCompletedPath(): Path = pathEnable
 
-    override fun getPathDisable(): Path = pathDisable
+    override fun getRemainingPath(): Path = pathDisable
 
-    override fun printTitle(
+    override fun drawTitle(
         canvas: Canvas,
         title: String,
         x: Float,
@@ -134,7 +140,7 @@ class LinearTimelineUi(
         canvas.drawText(title, x, y, textPaint)
     }
 
-    override fun printDescription(
+    override fun drawDescription(
         canvas: Canvas,
         description: String,
         x: Float,
@@ -151,8 +157,8 @@ class LinearTimelineUi(
         canvas.drawText(description, x, y, textPaint)
     }
 
-    override fun printIcon(
-        lvl: TimelineStep,
+    override fun drawStepIcon(
+        step: TimelineStep,
         canvas: Canvas,
         align: Paint.Align,
         context: Context,
@@ -160,7 +166,7 @@ class LinearTimelineUi(
         y: Float
     ) {
         val bm: Bitmap? = when {
-            lvl.count == lvl.maxCount && lvl.icon != 0 -> getBitmap(lvl.icon, context)
+            step.count == step.maxCount && step.icon != 0 -> getBitmap(step.icon, context)
             else -> iconDisableStep
         }
         bm?.let {
@@ -169,6 +175,9 @@ class LinearTimelineUi(
         }
     }
 
+    /**
+     * Получение Bitmap из ресурса, включая поддержку VectorDrawable.
+     */
     private fun getBitmap(drawableId: Int, context: Context): Bitmap? {
         if (drawableId == 0) return null
 
@@ -186,6 +195,5 @@ class LinearTimelineUi(
         }
     }
 
-    override fun getTextAlign(): Paint.Align = textPaint.textAlign
+    override fun getTextAlignment(): Paint.Align = textPaint.textAlign
 }
-

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/render/TimelineUiRenderer.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/render/TimelineUiRenderer.kt
@@ -1,12 +1,12 @@
-package com.dmitrypokrasov.timelineview.domain
+package com.dmitrypokrasov.timelineview.render
 
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Path
-import com.dmitrypokrasov.timelineview.data.TimelineStep
-import com.dmitrypokrasov.timelineview.domain.data.TimelineMathConfig
-import com.dmitrypokrasov.timelineview.domain.data.TimelineUiConfig
+import com.dmitrypokrasov.timelineview.model.TimelineStep
+import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
+import com.dmitrypokrasov.timelineview.config.TimelineUiConfig
 
 /**
  * Интерфейс рендерера временной шкалы.
@@ -34,15 +34,15 @@ interface TimelineUiRenderer {
     /**
      * Сбрасывает и настраивает кисть для рисования линий.
      */
-    fun resetFromPaintTools()
+    fun prepareStrokePaint()
 
     /**
      * Сбрасывает и настраивает кисть для рисования текста.
      */
-    fun resetFromTextTools()
+    fun prepareTextPaint()
 
     /** Сбрасывает и настраивает кисть для рисования иконок. */
-    fun resetFromIconTools()
+    fun prepareIconPaint()
 
     /**
      * Рисует bitmap текущего прогресса.
@@ -51,23 +51,23 @@ interface TimelineUiRenderer {
      * @param leftCoordinates левая координата вывода
      * @param topCoordinates верхняя координата вывода
      */
-    fun drawProgressBitmap(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float)
+    fun drawProgressIcon(canvas: Canvas, leftCoordinates: Float, topCoordinates: Float)
 
     /**
      * Рисует путь пройденных шагов.
      */
-    fun drawProgressPath(canvas: Canvas)
+    fun drawCompletedPath(canvas: Canvas)
 
     /**
      * Рисует путь непройденных шагов.
      */
-    fun drawDisablePath(canvas: Canvas)
+    fun drawRemainingPath(canvas: Canvas)
 
     /** Возвращает путь пройденных шагов. */
-    fun getPathEnable(): Path
+    fun getCompletedPath(): Path
 
     /** Возвращает путь непройденных шагов. */
-    fun getPathDisable(): Path
+    fun getRemainingPath(): Path
 
     /**
      * Печатает заголовок шага.
@@ -78,7 +78,7 @@ interface TimelineUiRenderer {
      * @param y Y-координата текста
      * @param align выравнивание текста
      */
-    fun printTitle(canvas: Canvas, title: String, x: Float, y: Float, align: Paint.Align)
+    fun drawTitle(canvas: Canvas, title: String, x: Float, y: Float, align: Paint.Align)
 
     /**
      * Печатает описание шага.
@@ -89,24 +89,24 @@ interface TimelineUiRenderer {
      * @param y Y-координата текста
      * @param align выравнивание текста
      */
-    fun printDescription(canvas: Canvas, description: String, x: Float, y: Float, align: Paint.Align)
+    fun drawDescription(canvas: Canvas, description: String, x: Float, y: Float, align: Paint.Align)
 
     /**
      * Рисует иконку шага.
      *
      * В зависимости от состояния шага выбирает соответствующий ресурс.
      *
-     * @param lvl данные шага
+     * @param step данные шага
      * @param canvas холст для рисования
      * @param align выравнивание иконки
      * @param context Android контекст для получения ресурсов
      * @param x X-координата иконки
      * @param y Y-координата иконки
      */
-    fun printIcon(lvl: TimelineStep, canvas: Canvas, align: Paint.Align, context: Context, x: Float, y: Float)
+    fun drawStepIcon(step: TimelineStep, canvas: Canvas, align: Paint.Align, context: Context, x: Float, y: Float)
 
     /**
      * Возвращает текущее выравнивание текста, используемое кистью.
      */
-    fun getTextAlign(): Paint.Align
+    fun getTextAlignment(): Paint.Align
 }


### PR DESCRIPTION
## Summary
- refactor library packages into model, config, math, render, and ui
- unify configuration handling with `TimelineConfig` and parser
- rename UI renderer methods for clearer contracts and update docs

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c0791d1bfc8322bbb3077b86bc10ba