### PR TITLE
Скорректировать смещение блоков тайм

### DIFF
--- a/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleData.kt
+++ b/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleData.kt
@@ -8,6 +8,13 @@ import com.dmitrypokrasov.timelineview.model.TimelineLottieSpec
 import com.dmitrypokrasov.timelineview.model.TimelineStepData
 
 object TimelineSampleData {
+    fun buildCompletionBadgeAnimation(): TimelineLottieSpec =
+        TimelineLottieSpec(
+            rawRes = R.raw.timeline_badge_pulse,
+            repeat = false,
+            scale = 1.2f
+        )
+
     fun buildSteps(context: Context): List<TimelineStepData> {
         fun progress(count: Int, maxCount: Int): Int {
             return if (maxCount <= 0) {
@@ -50,7 +57,7 @@ object TimelineSampleData {
             TimelineStepData(
                 title = context.getString(R.string.title_5_lvl),
                 description = context.getString(R.string.description_500_699_steps),
-                iconRes = R.drawable.ic_unactive,
+                iconRes = R.drawable.ic_active,
                 iconDisabledRes = R.drawable.ic_unactive,
                 progress = progress(0, 49)
             )

--- a/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleFragment.kt
+++ b/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleFragment.kt
@@ -31,14 +31,30 @@ class TimelineSampleFragment : Fragment() {
         val timelineView = view.findViewById<TimelineView>(R.id.timeline)
         val sample = requireSample()
 
-        val steps = TimelineSampleData.buildSteps(requireContext())
+        var steps = TimelineSampleData.buildSteps(requireContext())
         val mathConfig = TimelineSampleData.buildMathConfig(requireContext(), steps)
         val uiConfig = TimelineSampleData.buildUiConfig(requireContext())
 
         timelineView.replaceSteps(steps)
 
         timelineView.setOnStepClickListener { index, _ ->
-            Toast.makeText(requireContext(), "Step index: $index", Toast.LENGTH_SHORT).show()
+            steps = steps.mapIndexed { stepIndex, step ->
+                if (stepIndex != index) {
+                    step
+                } else {
+                    val updatedProgress = (step.progress + 10).coerceAtMost(100)
+                    val justCompleted = step.progress < 100 && updatedProgress == 100
+                    step.copy(
+                        progress = updatedProgress,
+                        badgeAnimation = if (justCompleted) {
+                            TimelineSampleData.buildCompletionBadgeAnimation()
+                        } else {
+                            step.badgeAnimation
+                        }
+                    )
+                }
+            }
+            timelineView.replaceSteps(steps)
         }
         timelineView.setOnProgressIconClickListener {
             val progressIndex = resolveProgressStepIndex(steps)

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMath.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMath.kt
@@ -21,7 +21,6 @@ class LinearTimelineMath(
         val end: Float,
     ) {
         val length: Float get() = end - start
-        val anchor: Float get() = end
     }
 
     enum class Orientation { VERTICAL, HORIZONTAL }
@@ -47,18 +46,20 @@ class LinearTimelineMath(
         pathEnable.reset()
         pathDisable.reset()
 
+        val segments = getSegments()
         val crossAxis = if (orientation == Orientation.VERTICAL) 0f else getHorizontalBaseline()
+        val pathStart = segments.firstOrNull()?.start ?: 0f
         pathEnable.moveTo(
-            if (orientation == Orientation.VERTICAL) 0f else 0f,
-            if (orientation == Orientation.VERTICAL) 0f else crossAxis
+            if (orientation == Orientation.VERTICAL) 0f else pathStart,
+            if (orientation == Orientation.VERTICAL) pathStart else crossAxis
         )
         pathDisable.moveTo(
-            if (orientation == Orientation.VERTICAL) 0f else 0f,
-            if (orientation == Orientation.VERTICAL) 0f else crossAxis
+            if (orientation == Orientation.VERTICAL) 0f else pathStart,
+            if (orientation == Orientation.VERTICAL) pathStart else crossAxis
         )
 
         var drawEnable = true
-        getSegments().forEachIndexed { index, segment ->
+        segments.forEachIndexed { index, segment ->
             val progressPosition = segment.start + segment.length * mathConfig.steps[index].progress / 100f
             if (drawEnable) {
                 lineTo(pathEnable, progressPosition, crossAxis)
@@ -92,6 +93,7 @@ class LinearTimelineMath(
                     measuredWidth.toFloat() - totalLength - mathConfig.spacing.marginHorizontalStroke
             }
         }
+        segmentsValid = false
     }
 
     override fun getHorizontalIconOffset(i: Int): Float {
@@ -181,7 +183,7 @@ class LinearTimelineMath(
     private fun getVerticalContentInset(): Float =
         maxOf(mathConfig.sizes.sizeImageLvl, mathConfig.sizes.sizeIconProgress) / 2f
 
-    private fun getAnchorPosition(index: Int): Float {
+    private fun getBadgeCenterPosition(index: Int): Float {
         return if (orientation == Orientation.VERTICAL) {
             getVerticalContentInset() + mathConfig.spacing.stepYFirst + mathConfig.spacing.stepY * index
         } else {
@@ -190,7 +192,7 @@ class LinearTimelineMath(
     }
 
     private fun getTotalLength(): Float =
-        if (mathConfig.steps.isEmpty()) 0f else getAnchorPosition(mathConfig.steps.lastIndex)
+        if (mathConfig.steps.isEmpty()) 0f else getBadgeCenterPosition(mathConfig.steps.lastIndex)
 
     private fun getHorizontalProgressTop(): Float =
         getHorizontalBaseline() - mathConfig.sizes.sizeIconProgress / 2f
@@ -201,7 +203,7 @@ class LinearTimelineMath(
     override fun buildLayout(): TimelineLayout {
         val layoutSteps = if (orientation == Orientation.HORIZONTAL) {
             mathConfig.steps.mapIndexed { index, step ->
-                val positionX = getStepPosition(index)
+                val positionX = getBadgeCenterPosition(index)
                 val baseline = getHorizontalBaseline()
                 val titleWidth = TimelineTextWidthResolver.resolve(
                     measuredWidth = measuredWidth,
@@ -279,9 +281,9 @@ class LinearTimelineMath(
     }
 
     private fun buildSegments(): List<SegmentInfo> {
-        var previous = 0f
+        var previous = getPathStart()
         return mathConfig.steps.indices.map { index ->
-            val anchor = getAnchorPosition(index)
+            val anchor = getSegmentEndPosition(index)
             SegmentInfo(start = previous, end = anchor).also {
                 previous = anchor
             }
@@ -297,7 +299,8 @@ class LinearTimelineMath(
     }
 
     private fun getStepPosition(index: Int): Float =
-        getSegments().getOrNull(index)?.anchor ?: if (orientation == Orientation.VERTICAL) {
+        mathConfig.steps.getOrNull(index)?.let { getBadgeCenterPosition(index) }
+            ?: if (orientation == Orientation.VERTICAL) {
             getVerticalContentInset()
         } else {
             0f
@@ -308,6 +311,26 @@ class LinearTimelineMath(
         val progress = segment.length * mathConfig.steps[index].progress / 100f
         return segment.start + progress
     }
+
+    private fun getPathStart(): Float =
+        if (orientation == Orientation.VERTICAL) 0f else -getHorizontalLeadIn()
+
+    private fun getSegmentEndPosition(index: Int): Float {
+        val badgeCenter = getBadgeCenterPosition(index)
+        return if (orientation == Orientation.HORIZONTAL && index == mathConfig.steps.lastIndex) {
+            badgeCenter - getHorizontalTerminalInset()
+        } else {
+            badgeCenter
+        }
+    }
+
+    private fun getHorizontalLeadIn(): Float =
+        (startPositionX + mathConfig.sizes.sizeImageLvl / 2f).coerceAtLeast(
+            mathConfig.sizes.sizeImageLvl / 2f
+        )
+
+    private fun getHorizontalTerminalInset(): Float =
+        (mathConfig.sizes.sizeImageLvl / 2f - 2f).coerceAtLeast(0f)
 
     private fun moveTo(path: Path, value: Float, crossAxis: Float) {
         if (orientation == Orientation.VERTICAL) {
@@ -325,4 +348,3 @@ class LinearTimelineMath(
         }
     }
 }
-

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineLottieOverlayManager.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineLottieOverlayManager.kt
@@ -6,12 +6,18 @@ import android.view.View
 import com.airbnb.lottie.LottieCompositionFactory
 import com.airbnb.lottie.LottieDrawable
 import com.dmitrypokrasov.timelineview.model.TimelineLottieSpec
+import java.util.IdentityHashMap
 import kotlin.math.roundToInt
 
 internal class TimelineLottieOverlayManager(
     private val ownerView: View
 ) {
-    private val drawableCache = mutableMapOf<TimelineLottieSpec, LottieDrawable>()
+    private data class OverlayEntry(
+        val drawable: LottieDrawable,
+        var autoPlayConsumed: Boolean = false
+    )
+
+    private val drawableCache = IdentityHashMap<TimelineLottieSpec, OverlayEntry>()
 
     fun draw(
         canvas: Canvas,
@@ -23,9 +29,10 @@ internal class TimelineLottieOverlayManager(
     ) {
         if (spec == null) return
 
-        val drawable = drawableCache.getOrPut(spec) {
-            createDrawable(context, spec)
+        val entry = drawableCache.getOrPut(spec) {
+            OverlayEntry(createDrawable(context, spec))
         }
+        val drawable = entry.drawable
 
         val scaledSize = size * spec.scale
         val inset = (size - scaledSize) / 2f
@@ -38,10 +45,21 @@ internal class TimelineLottieOverlayManager(
             (drawTop + scaledSize).roundToInt()
         )
 
-        if (spec.autoPlay && !drawable.isAnimating) {
-            drawable.playAnimation()
-        }
-        if (!spec.autoPlay && drawable.isAnimating) {
+        if (spec.autoPlay) {
+            if (spec.repeat) {
+                if (!drawable.isAnimating) {
+                    drawable.playAnimation()
+                }
+            } else {
+                if (!entry.autoPlayConsumed) {
+                    drawable.progress = 0f
+                    drawable.playAnimation()
+                    entry.autoPlayConsumed = true
+                } else if (!drawable.isAnimating && drawable.progress >= 1f) {
+                    return
+                }
+            }
+        } else if (drawable.isAnimating) {
             drawable.pauseAnimation()
         }
 
@@ -49,9 +67,9 @@ internal class TimelineLottieOverlayManager(
     }
 
     fun clear() {
-        drawableCache.values.forEach { drawable ->
-            drawable.cancelAnimation()
-            drawable.callback = null
+        drawableCache.values.forEach { entry ->
+            entry.drawable.cancelAnimation()
+            entry.drawable.callback = null
         }
         drawableCache.clear()
     }

--- a/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineTextBlockResolver.kt
+++ b/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineTextBlockResolver.kt
@@ -2,6 +2,7 @@ package com.dmitrypokrasov.timelineview.ui
 
 import com.dmitrypokrasov.timelineview.config.TimelineMathConfig
 import com.dmitrypokrasov.timelineview.math.LinearTimelineMath
+import com.dmitrypokrasov.timelineview.math.SnakeTimelineMath
 import com.dmitrypokrasov.timelineview.math.TimelineMathEngine
 import com.dmitrypokrasov.timelineview.math.data.TimelineLayout
 import com.dmitrypokrasov.timelineview.render.TimelineUiRenderer
@@ -24,10 +25,20 @@ internal object TimelineTextBlockResolver {
 
         val isLinearVertical = mathEngine is LinearTimelineMath &&
             mathEngine.orientation == LinearTimelineMath.Orientation.VERTICAL
+        val isSnake = mathEngine is SnakeTimelineMath
         val minGapBetweenTitleAndDescription = 4f
         val minGapBetweenSteps = 4f
         val linearVerticalLift = if (isLinearVertical) {
-            (mathConfig.spacing.stepYFirst / 2f + mathConfig.spacing.stepYFirst / 10f + mathConfig.spacing.stepYFirst / 20f).coerceAtLeast(6f)
+            (
+                    mathConfig.spacing.stepYFirst / 2f +
+                            mathConfig.spacing.stepYFirst / 10f +
+                            mathConfig.spacing.stepYFirst / 20f
+                    ).coerceAtLeast(6f) + 4f
+        } else {
+            0f
+        }
+        val snakeTextDrop = if (isSnake) {
+            mathConfig.spacing.marginTopDescription.coerceIn(4f, 8f)
         } else {
             0f
         }
@@ -45,9 +56,10 @@ internal object TimelineTextBlockResolver {
                 stepLayout.textAlign
             )
 
-            var titleTop = stepLayout.titleY - uiRenderer.getTitleBaselineOffset() - linearVerticalLift
+            var titleTop = stepLayout.titleY - uiRenderer.getTitleBaselineOffset() -
+                    linearVerticalLift + snakeTextDrop
             var descriptionTop = stepLayout.descriptionY - uiRenderer.getDescriptionBaselineOffset() -
-                linearVerticalLift
+                    linearVerticalLift + snakeTextDrop
             descriptionTop = maxOf(descriptionTop, titleTop + titleHeight + minGapBetweenTitleAndDescription)
 
             if (isLinearVertical) {
@@ -69,5 +81,3 @@ internal object TimelineTextBlockResolver {
         }
     }
 }
-
-

--- a/timelineview/src/test/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMathTest.kt
+++ b/timelineview/src/test/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMathTest.kt
@@ -40,18 +40,19 @@ class LinearTimelineMathTest {
 
         val layout = math.buildLayout()
 
-        val expectedLeft = -config.sizes.sizeIconProgress / 2f
+        val expectedLeft = -(config.sizes.sizeImageLvl / 2f) - config.sizes.sizeIconProgress / 2f
         assertEquals(expectedLeft, requireNotNull(layout.progressIcon).left, 0.01f)
     }
 
     @Test
-    fun `horizontal last segment ends at last badge anchor`() {
+    fun `horizontal last segment ends inside last badge`() {
         val config = progressConfig(progresses = listOf(100, 100, 100))
         val math = LinearTimelineMath(config, LinearTimelineMath.Orientation.HORIZONTAL)
 
         val lastIndex = config.steps.lastIndex
         val lastAnchor = math.getHorizontalIconOffset(lastIndex) + config.sizes.sizeIconProgress / 2f
-        val expectedAnchor = config.spacing.stepYFirst + config.spacing.stepY * lastIndex
+        val expectedAnchor = config.spacing.stepYFirst + config.spacing.stepY * lastIndex -
+                (config.sizes.sizeImageLvl / 2f - 2f)
 
         assertEquals(expectedAnchor, lastAnchor, 0.01f)
     }


### PR DESCRIPTION
Подправил демо и геометрию таймлайна под твои пункты.

В [TimelineSampleFragment.kt](/Users/dmitr/AndroidStudioProjects/Timeline/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleFragment.kt#L30) клик по бейджу теперь добавляет `+10%` к `progress`, сразу вызывает `replaceSteps()` и перерисовывает таймлайн. Если шаг на этом клике добивается до `100`, ему подставляется одноразовая badge-анимация. Саму анимацию и активную иконку для последнего шага добавил в [TimelineSampleData.kt](/Users/dmitr/AndroidStudioProjects/Timeline/app/src/main/java/com/dmitrypokrasov/timeline/TimelineSampleData.kt#L10).

В [LinearTimelineMath.kt](/Users/dmitr/AndroidStudioProjects/Timeline/timelineview/src/main/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMath.kt#L45) горизонтальную линию пересчитал так, чтобы она стартовала левее экрана и заходила в первый бейдж, а последний сегмент заканчивался внутри последнего бейджа. В [TimelineTextBlockResolver.kt](/Users/dmitr/AndroidStudioProjects/Timeline/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineTextBlockResolver.kt#L26) чуть опустил блок `title/description` для `snake` и чуть сильнее поднял для `linear vertical`. В [TimelineLottieOverlayManager.kt](/Users/dmitr/AndroidStudioProjects/Timeline/timelineview/src/main/java/com/dmitrypokrasov/timelineview/ui/TimelineLottieOverlayManager.kt#L12) одноразовые Lottie-overlay больше не зависают последним кадром и не перезапускаются бесконечно. Проверки под новую горизонтальную математику обновил в [LinearTimelineMathTest.kt](/Users/dmitr/AndroidStudioProjects/Timeline/timelineview/src/test/java/com/dmitrypokrasov/timelineview/math/LinearTimelineMathTest.kt#L36).

Проверил:
- `.\gradlew.bat --offline :app:compileDebugKotlin`
- `.\gradlew.bat --offline :timelineview:testDebugUnitTest`

В рабочем дереве уже был сторонний изменённый `gradle.properties`; я его не трогал.